### PR TITLE
Starting bring all potentially used micro flags into yaml

### DIFF
--- a/application.dist.yaml
+++ b/application.dist.yaml
@@ -4,3 +4,6 @@ bot:
   botToken: You bot token here, do not prepend Bot... we'll do that for you
   authSrvNamespace: namespace that the auth-srv instance lives in
   discordServerId: https://support.discordapp.com/hc/en-us/articles/206346498-Where-can-I-find-my-server-ID-
+registry:
+  hostname: localhost
+  port: 8500

--- a/main.go
+++ b/main.go
@@ -17,7 +17,7 @@ var version string = "1.0.0"
 var service micro.Service
 
 func main() {
-	service = config.NewService(version, initialize)
+	service = config.NewService(version, "auth", initialize)
 
 	if err := service.Run(); err != nil {
 		fmt.Println(err)


### PR DESCRIPTION
Configuration files other than process management configuration files
are slightly more consumable by users.  Bringing in all relevant flags
from micro into our own configuration seems useful in this regard.